### PR TITLE
Require newer version of ember template lint in CI 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-template-lint": "^1.0.0-beta.1",
+    "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
@@ -62,6 +62,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "resolutions": {
+    "ember-cli-template-lint/**/ember-template-lint": "^1.4.0"
   },
   "homepage": "https://square.github.io/ember-square-payment-form"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,15 +875,15 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
-"@glimmer/compiler@^0.38.0":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.38.4.tgz#ea5f39b9681a652dd96c48eeb55cd95aa6f6eddd"
-  integrity sha512-AQdDqInUM0yrUUEFdkNI2GR/WPfWN4HvbZYwgBet7TGicvfWXXLe76TI65H03SnPzoh835FDq2XcWLqlgwYt9w==
+"@glimmer/compiler@^0.41.0":
+  version "0.41.4"
+  resolved "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.41.4.tgz#c3b6f241bebe99373f64882902512b67aaee49f8"
+  integrity sha512-JTdFJDp0irQptXCqDQUPWaB7p6/Bg2SKe7NIMoeKeRGAw0Nhgi0xkqTN7OF2sugfjMdmzRn1oHRL5Mk26VZtfw==
   dependencies:
-    "@glimmer/interfaces" "^0.38.4"
-    "@glimmer/syntax" "^0.38.4"
-    "@glimmer/util" "^0.38.4"
-    "@glimmer/wire-format" "^0.38.4"
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/syntax" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+    "@glimmer/wire-format" "^0.41.4"
 
 "@glimmer/di@^0.2.0":
   version "0.2.1"
@@ -902,13 +902,10 @@
   dependencies:
     "@glimmer/wire-format" "^0.36.6"
 
-"@glimmer/interfaces@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.38.4.tgz#437663eb07b97a22c8348a47b25191b5c5198bf3"
-  integrity sha512-Kuc2BNOZMnwmdZh3jOLUktVu9V0BASCRAslPmVfhzgPjD3j9VzqNOifD7eBz/ZvWqpS1e7CgBEc42CBlCBUfnQ==
-  dependencies:
-    "@glimmer/wire-format" "^0.38.4"
-    "@simple-dom/interface" "1.4.0"
+"@glimmer/interfaces@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.41.4.tgz#3f3e26abea8a4e1463130e9a75e94372781d154b"
+  integrity sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==
 
 "@glimmer/resolver@^0.4.1":
   version "0.4.3"
@@ -927,25 +924,25 @@
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.5.6"
 
-"@glimmer/syntax@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.38.4.tgz#eac34167cfa80daabb5db25fece1982c17a063f1"
-  integrity sha512-aB5vNC4ADCFXQWORFnx1kG8DtaWqS9E2zkynnj8/GqfYjO4yBtM0HFqBHAEIfcD8Zm+zK4osghs2YGrKvIsEdg==
+"@glimmer/syntax@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.41.4.tgz#9c0c763aab44069c828ce782947c84d31ff75879"
+  integrity sha512-NLPNirZDbNmpZ8T/ccle22zt2rhUq5il7ST6IJk62T58QZeJsdr3m3RS4kaGSBsQhXoKELrgX048yYEX5sC+fw==
   dependencies:
-    "@glimmer/interfaces" "^0.38.4"
-    "@glimmer/util" "^0.38.4"
-    handlebars "^4.0.6"
-    simple-html-tokenizer "^0.5.6"
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+    handlebars "^4.0.13"
+    simple-html-tokenizer "^0.5.7"
 
 "@glimmer/util@^0.36.6":
   version "0.36.6"
   resolved "https://registry.npmjs.org/@glimmer/util/-/util-0.36.6.tgz#0b36d571ef2f052011f73f379593385ec1abd308"
   integrity sha512-ljlXwrtg3yhftH/TX8VXNEpqkoweNRumhRq41Y8diGnd7wFWiuiWZUWghTcpAFtilVCOc2e+9WvdvUWTISM1MA==
 
-"@glimmer/util@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.38.4.tgz#43b4fbdf98c8c244ac7d1bfd95fef9c8f7761ad5"
-  integrity sha512-qFU96hAcDjK3ZD8lVJMB+FOJjCm+qZydiUICDj/CYTx82bSOfkzpHLNQ5OivJpsVl1+jFqJolQwrjqFC1bQJHA==
+"@glimmer/util@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.npmjs.org/@glimmer/util/-/util-0.41.4.tgz#508fd82ca40305416e130f0da7b537295ded7989"
+  integrity sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==
 
 "@glimmer/wire-format@^0.36.6":
   version "0.36.6"
@@ -954,12 +951,13 @@
   dependencies:
     "@glimmer/util" "^0.36.6"
 
-"@glimmer/wire-format@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.38.4.tgz#efbfe757b05e32344855b01804cc19dcca0d0828"
-  integrity sha512-1K8N+mbUtqJ1/MR+E/kDekC53HJNecU1i0TUAz5Vh24cvBcPCWP63YtwyCOxfnn7MLFdl8/QvHuo3+8Uxw+oVg==
+"@glimmer/wire-format@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.41.4.tgz#edc3279b8216363c925e771b2e2cbe408f2a0812"
+  integrity sha512-vp3Z+PjYkgCCyj5HX3cFB6Mag76GwVkI0cx9vMHKDoqJFJBicxc9JPymNuPuEithsJpUXJj2g7TKwJaliH2+cw==
   dependencies:
-    "@glimmer/util" "^0.38.4"
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -973,11 +971,6 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
-
-"@simple-dom/interface@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
-  integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
@@ -5215,9 +5208,9 @@ ember-cli-tailwind@^0.6.2:
     rollup-plugin-node-resolve "^3.3.0"
     tailwindcss "^0.6.1"
 
-ember-cli-template-lint@^1.0.0-beta.1:
+ember-cli-template-lint@^1.0.0-beta.3:
   version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-template-lint/-/ember-cli-template-lint-1.0.0-beta.3.tgz#48f2fa43e7ad0172685fa171e5acd4d75b873792"
+  resolved "https://registry.npmjs.org/ember-cli-template-lint/-/ember-cli-template-lint-1.0.0-beta.3.tgz#48f2fa43e7ad0172685fa171e5acd4d75b873792"
   integrity sha512-ivrvYih+cx7VUlyyMQBmk61Ki+gT5axfppWrk6fSvHaoxHZadXU3zRJMT5DPkeRaayRu0y1dls4wqfrUhzQ1PA==
   dependencies:
     aot-test-generators "^0.1.0"
@@ -5707,12 +5700,12 @@ ember-svg-jar@^1.2.2:
     mkdirp "^0.5.1"
     path-posix "^1.0.0"
 
-ember-template-lint@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-1.1.0.tgz#312e101728452bf082f54cbe429ed9b52273ba64"
-  integrity sha512-DPEWdjaNVIC58wJqeJStvQzk2gyKN5/u6dJfDKQ7mRJaouoLP1hZjSZwwpyO9bj10E9/3OJZnLmx1jjJ9/nqWA==
+ember-template-lint@^1.1.0, ember-template-lint@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.2.tgz#914811b1d1715508d08eff470eb3c19ae7b9027f"
+  integrity sha512-uAGmYrIHoBS8jjmvb2SNprX5zPEs647amO+OHT0OtrO1HjFnhS4GyOXH2xx6h38co65WpPll0o3HFyE4cEh0NA==
   dependencies:
-    "@glimmer/compiler" "^0.38.0"
+    "@glimmer/compiler" "^0.41.0"
     chalk "^2.0.0"
     globby "^9.0.0"
     minimatch "^3.0.4"
@@ -7017,7 +7010,7 @@ growly@^1.3.0:
   resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.0.6, handlebars@~4.1.2:
+handlebars@^4.0.11, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.0.6, handlebars@~4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -10882,7 +10875,7 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1
   dependencies:
     debug "^2.2.0"
 
-simple-html-tokenizer@^0.5.6:
+simple-html-tokenizer@^0.5.6, simple-html-tokenizer@^0.5.7:
   version "0.5.8"
   resolved "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz#3417382f75954ee34515cc4fd32d9918e693f173"
   integrity sha512-0Sq4FvLlQEQODVA6PH2MIrc7tzYO0KT2HzzwvaVLYClWgIsuvaNUOrhrAvTi1pZHrcq7GDB4WiI3ukjqBMxcGQ==


### PR DESCRIPTION
Per comment here: https://github.com/ember-template-lint/ember-template-lint/issues/777