### PR TITLE
docs: Fix 'Dark theme' links

### DIFF
--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -52,5 +52,5 @@ charge customers.
 Take a look at our examples for inspiration:
 
 - {{link-to "Styled Payment Form - Light Theme" "examples.light"}}
-- {{link-to "Styled Payment Form - Dark Theme" "examples.light"}}
+- {{link-to "Styled Payment Form - Dark Theme" "examples.dark"}}
 - {{link-to "Unstyled Payment Form" "examples.unstyled"}}

--- a/tests/dummy/app/templates/examples/index.md
+++ b/tests/dummy/app/templates/examples/index.md
@@ -4,7 +4,7 @@ To help you get started, we've made 3 examples of how to use the Square Payment 
 in your app.
 
 - {{link-to "Styled Payment Form - Light Theme" "examples.light"}}
-- {{link-to "Styled Payment Form - Dark Theme" "examples.light"}}
+- {{link-to "Styled Payment Form - Dark Theme" "examples.dark"}}
 - {{link-to "Unstyled Payment Form" "examples.unstyled"}}
 
 If you're looking to get up and running quickly, we recommend you start with our styled payment form.


### PR DESCRIPTION
'Dark theme' links were pointing to the light theme.