### PR TITLE
Add support for specifying URL the payment form loads from

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,29 @@ const Funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const join = require('path').join;
 
+function jsUrlForEnvironment(config) {
+  if (config.squarePaymentForm) {
+    if (config.squarePaymentForm.jsUrl) {
+      return config.squarePaymentForm.jsUrl;
+    } else if (config.squarePaymentForm.environment === 'sandbox') {
+      return 'https://js.squareupsandbox.com/v2/paymentform';
+    }
+  }
+
+  // If we're in development or test mode, we probably want to use sandbox instead
+  // of production.
+  if (config.environment === 'development' || config.environment === 'test') {
+    return 'https://js.squareupsandbox.com/v2/paymentform';
+  } else {
+    return 'https://js.squareup.com/v2/paymentform';
+  }
+}
+
 module.exports = {
   name: require('./package').name,
-  contentFor(type) {
+  contentFor(type, config) {
     if (type === 'head') {
-      return '<script type="text/javascript" src="https://js.squareup.com/v2/paymentform"></script>';
+      return `<script type="text/javascript" src="${jsUrlForEnvironment(config)}"></script>`;
     }
   },
   treeForPublic: function() {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -46,6 +46,11 @@ module.exports = function(environment) {
   if (environment === 'production') {
     // Allow ember-cli-addon-docs to update the rootURL in compiled assets
     ENV.rootURL = 'ADDON_DOCS_ROOT_URL';
+
+    // Use sandbox mode in production since we aren't taking prod payments
+    ENV.squarePaymentForm = {
+      environment: 'sandbox'
+    };
     // here you can enable a production-specific feature
   }
 


### PR DESCRIPTION
With the new sandbox beta, we need a way to allow developers to specify whether they're in sandbox mode or production mode to load the sandbox CDN URL appropriately. This PR allows you to specify the payment form environment like this in your `environment.js` file:

```js
module.exports = function(environment) {
  var ENV = {
    modulePrefix: 'host',
    environment: environment,
    baseURL: '/',
    locationType: 'auto',
    EmberENV: {
      // ...
    },
    APP: {
      // ...
    },

    squarePaymentForm: {
      environment: 'sandbox'
    }
  };
};
```