### PR TITLE
Write test helpers for component integration tests with SqPaymentForm

### DIFF
--- a/addon-test-support/fixtures/card-nonce-response.js
+++ b/addon-test-support/fixtures/card-nonce-response.js
@@ -1,0 +1,96 @@
+export const INVALID_APPLICATION_ID_ERROR = {
+  errors: [
+    {
+      type: 'INVALID_APPLICATION_ID',
+      message: 'The application ID provided when initializing the payment form is invalid'
+    }
+  ]
+};
+
+export const MISSING_APPLICATION_ID_ERROR = {
+  errors: [
+    {
+      type: 'MISSING_APPLICATION_ID',
+      message: 'An application ID was not provided when initializing the payment form.'
+    }
+  ]
+};
+
+export const MISSING_CARD_DATA_ERROR = {
+  errors: [
+    {
+      type: 'MISSING_CARD_DATA',
+      message: 'One or more card data fields was not filled out in the payment form.'
+    }
+  ]
+};
+
+export const TOO_MANY_REQUESTS_ERROR = {
+  errors: [
+    {
+      type: 'TOO_MANY_REQUESTS',
+      message: 'Your application has generated too many nonce generation requests in too short a time. Try again later.'
+    }
+  ]
+};
+
+export const UNAUTHORIZED_ERROR = {
+  errors: [
+    {
+      type: 'UNAUTHORIZED',
+      message: 'Your application is not authorized to use the Connect API to accept online payments.'
+    }
+  ]
+};
+
+export const UNSUPPORTED_CARD_BRAND_ERROR = {
+  errors: [
+    {
+      type: 'UNSUPPORTED_CARD_BRAND',
+      message: 'Card is not supported',
+      field: 'cardNumber'
+    }
+  ]
+};
+
+export const UNKNOWN_ERROR = {
+  errors: [
+    {
+      type: 'UNKNOWN',
+      message: 'An unknown error occured'
+    }
+  ]
+};
+
+export const VALIDATION_ERROR = {
+  errors: [
+    {
+      type: 'VALIDATION_ERROR',
+      message: 'Card number is not valid',
+      field: 'cardNumber'
+    },
+    {
+      type: 'VALIDATION_ERROR',
+      message: 'CVV is not valid',
+      field: 'cvv'
+    },
+    {
+      type: 'VALIDATION_ERROR',
+      message: 'Expiration date is not valid',
+      field: 'expirationDate'
+    },
+    {
+      type: 'VALIDATION_ERROR',
+      message: 'Postal code is not valid',
+      field: 'postalCode'
+    }
+  ]
+};
+
+export const SUCCESS = {
+  nonce: 'card-nonce',
+  cardData: {},
+  billingContact: {},
+  shippingContact: {},
+  shippingOption: {}
+};

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,41 @@
+import {
+  INVALID_APPLICATION_ID_ERROR,
+  MISSING_APPLICATION_ID_ERROR,
+  MISSING_CARD_DATA_ERROR,
+  TOO_MANY_REQUESTS_ERROR,
+  UNAUTHORIZED_ERROR,
+  UNSUPPORTED_CARD_BRAND_ERROR,
+  UNKNOWN_ERROR,
+  VALIDATION_ERROR,
+  SUCCESS
+} from './fixtures/card-nonce-response';
+
+export {
+  INVALID_APPLICATION_ID_ERROR,
+  MISSING_APPLICATION_ID_ERROR,
+  MISSING_CARD_DATA_ERROR,
+  TOO_MANY_REQUESTS_ERROR,
+  UNAUTHORIZED_ERROR,
+  UNSUPPORTED_CARD_BRAND_ERROR,
+  UNKNOWN_ERROR,
+  VALIDATION_ERROR,
+  SUCCESS
+};
+
+let mockedCardNonceResponse = null;
+
+export function mockCardNonceResponse(response = UNKNOWN_ERROR) {
+  mockedCardNonceResponse = response;
+}
+
+export function setupSqPaymentForm(hooks) {
+  hooks.afterEach(function() {
+    mockedCardNonceResponse = null;
+  });
+}
+
+export function simulateRequestCardNonce(onCardNonceResponseReceived) {
+  const cardNonceResponse = mockedCardNonceResponse || UNKNOWN_ERROR;
+  const { errors, nonce, cardData, billingContact, shippingContact, shippingOption } = cardNonceResponse;
+  onCardNonceResponseReceived(errors, nonce, cardData, billingContact, shippingContact, shippingOption);
+}

--- a/addon/components/square-payment-form.js
+++ b/addon/components/square-payment-form.js
@@ -4,6 +4,7 @@ import randomId from '../utils/random-id';
 import template from '../templates/components/square-payment-form';
 import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
+import { simulateRequestCardNonce } from 'ember-square-payment-form/test-support';
 
 /**
  * Creates a Square Payment Form and yields form inputs to use inside of it.
@@ -578,7 +579,7 @@ export default Component.extend({
    * Used to determine if Apple Pay is supported in the current environment.
    * @private
    */
-  canShowMasterpas: false,
+  canShowMasterpass: false,
 
   /**
    * Checks if the form is to configured to accept any digital wallet payment methods
@@ -808,7 +809,11 @@ export default Component.extend({
      * @private
      */
     requestCardNonce() {
-      this.paymentForm && this.paymentForm.requestCardNonce();
+      if (Ember.testing) { // eslint-disable-line no-undef
+        simulateRequestCardNonce(this.onCardNonceResponseReceived);
+      } else {
+        this.paymentForm && this.paymentForm.requestCardNonce();
+      }
     }
   }
 });


### PR DESCRIPTION
Added some test fixtures and helpers to help write component integration tests for SqPaymentForm. 

The test fixtures are modeled based on the documentation on [Square developer docs](https://developer.squareup.com/docs/api/paymentform#cardnonceresponsereceived). The intended usage is:

```
test('it works', async function(assert) {
  mockCardNonceResponse(SUCCESS);

  await click('button.submit-form');

  const successMessageEl = await find('[x-payment-form-success-message]');
  assert.ok(successMessageEl);
});
```

It follows along the lines of a suggestion from @deanpapastrat , but is less flexible that what we discussed offline. Happy to iterate and address your comments. Let me know your thoughts.

