### PR TITLE
Add alpha support for the SCA flow

### DIFF
--- a/addon/templates/components/square-payment-form-styled.hbs
+++ b/addon/templates/components/square-payment-form-styled.hbs
@@ -9,6 +9,7 @@
   onCardNonceResponseReceived=this.onCardNonceResponseReceived
   shippingContactChanged=this.shippingContactChanged
   shippingOptionChanged=this.shippingOptionChanged
+  createVerificationDetails=this.createVerificationDetails
   as |PaymentForm|
 }}
   {{PaymentForm.ApplePayButton


### PR DESCRIPTION
This begins the workstream to support SCA to unblock internal Square teams, who will be helping us iterate on this before we solidify our approach and add tests / long-form documentation.

Related to #48.