### PR TITLE
Array-ify verification errors if necessary

### DIFF
--- a/addon/components/square-payment-form.js
+++ b/addon/components/square-payment-form.js
@@ -734,11 +734,12 @@ export default Component.extend({
           this.paymentForm.verifyBuyer(
             nonce,
             this.createVerificationDetails(),
-            (verificationErrors, result) => {
+            (verificationError, result) => {
+              const errors = verificationError ? [verificationError] : null;
               const verificationToken = result ? result.token : null;
 
               this.onCardNonceResponseReceived(
-                verificationErrors,
+                errors,
                 nonce,
                 cardData,
                 billingContact,


### PR DESCRIPTION
The callback signatures for `verifyBuyer` and `cardNonceResponseReceived` differ in that the former can return a single error while the latter can return multiple errors. This change should resolve that difference

[verifyBuyer reference](https://developer.squareup.com/docs/api/paymentform#verifybuyer)
[cardNonceResponseReceived reference](https://developer.squareup.com/docs/api/paymentform#cardnonceresponsereceived)