### PR TITLE
Adding deprecation information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,46 @@
-ember-square-payment-form
-==============================================================================
+# DEPRECATED - ember-square-payment-form
+
+**⛔️ The "Square Payment Form" is deprecated, and will no longer be supported aside from critical bug fixes. Please use the [Web Payments SDK](https://developer.squareup.com/docs/web-payments/overview) to take payments on a web client.**
 
 The Square Payment Form Ember addon lets you take payments securely and easily
 in your Ember app using a familiar, component-based syntax.
 
-*Note: this SDK is in beta. We'll be improving it as we work towards GA - please
-leave feedback for our team!*
+_Note: this SDK is in beta. We'll be improving it as we work towards GA - please
+leave feedback for our team!_
 
 [Read the Docs](https://square.github.io/ember-square-payment-form)
 
+## Compatibility
 
-Compatibility
-------------------------------------------------------------------------------
+- Ember.js v3.0 or above
+- Ember CLI v3.0 or above
 
-* Ember.js v3.0 or above
-* Ember CLI v3.0 or above
-
-Contributing
-------------------------------------------------------------------------------
+## Contributing
 
 ### Installation
 
-* `git clone <repository-url>`
-* `cd ember-square-payment-form`
-* `yarn install`
+- `git clone <repository-url>`
+- `cd ember-square-payment-form`
+- `yarn install`
 
 ### Linting
 
-* `yarn lint:hbs`
-* `yarn lint:js`
-* `yarn lint:js --fix`
+- `yarn lint:hbs`
+- `yarn lint:js`
+- `yarn lint:js --fix`
 
 ### Running tests
 
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
+- `ember test` – Runs the test suite on the current Ember version
+- `ember test --server` – Runs the test suite in "watch mode"
+- `ember try:each` – Runs the test suite against multiple Ember versions
 
 ### Running the dummy application
 
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+- `ember serve`
+- Visit the dummy application at [http://localhost:4200](http://localhost:4200).
 
-
-License
-------------------------------------------------------------------------------
+## License
 
 Copyright 2019 Square, Inc.
 


### PR DESCRIPTION
The Square Payment Form is now deprecated in favor of the [Web Payments SDK](https://developer.squareup.com/docs/web-payments/overview). This means this repo will not receive any new features moving forward aside from critical bug fixes.