### PR TITLE
Add deprecation warning for SqPaymentForm on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "ember build",
+    "postinstall": "node postInstall.js",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
+    "colors": "^1.4.0",
     "ember-cli": "^3.0.0",
     "ember-cli-addon-docs": "^0.6.7",
     "ember-cli-addon-docs-yuidoc": "^0.2.1",

--- a/postInstall.js
+++ b/postInstall.js
@@ -1,0 +1,3 @@
+const colors = require('colors');
+
+console.log(colors.red('On 2022-07-15, SqPaymentForm will be retired and functionality will no longer work. We encourage you to upgrade to the Web Payments SDK \n > https://developer.squareup.com/docs/web-payments/overview'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4148,10 +4148,10 @@ colors@1.0.3:
   resolved "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2:
+colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+  resolved "https://artifactory.global.square/artifactory/api/npm/square-npm/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha1-xQSRR51MG9rtLJztMs98fcI2D3g=
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4150,8 +4150,8 @@ colors@1.0.3:
 
 colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
-  resolved "https://artifactory.global.square/artifactory/api/npm/square-npm/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha1-xQSRR51MG9rtLJztMs98fcI2D3g=
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"


### PR DESCRIPTION
SqPaymentForm is offiically deprecated. We recommend developers migrate to the [Web Payments SDK ](https://developer.squareup.com/docs/web-payments/overview)

This will log a warning on postInstall of this package.

<img width="982" alt="Screen Shot 2021-07-09 at 3 18 07 PM" src="https://user-images.githubusercontent.com/1824604/125126298-df567b80-e0c8-11eb-9899-5adccf958951.png">
